### PR TITLE
Refactor generator object composition and extensions

### DIFF
--- a/lib/hotpages/dev_server.rb
+++ b/lib/hotpages/dev_server.rb
@@ -44,7 +44,7 @@ class Hotpages::DevServer
   def gem_development? = !!@gem_development
 
   def page_finder
-    @page_finder ||= Hotpages::Page::Finder.new(site)
+    @page_finder ||= Hotpages::PageFinder.new(site)
   end
 
   def setup_routes

--- a/lib/hotpages/extension.rb
+++ b/lib/hotpages/extension.rb
@@ -15,7 +15,7 @@ module Hotpages::Extension
         when :include
           base.include(with)
           if with.const_defined?(:ClassMethods, false)
-            base.extend(with)
+            base.extend(with::ClassMethods)
           end
         else
           raise "Unknown extension type: #{type}"

--- a/lib/hotpages/extension.rb
+++ b/lib/hotpages/extension.rb
@@ -1,3 +1,4 @@
+# TODO: Find more simple way to use prepend/include directly.
 module Hotpages::Extension
   using Hotpages::Support::StringInflections
 

--- a/lib/hotpages/extensions/i18n.rb
+++ b/lib/hotpages/extensions/i18n.rb
@@ -4,7 +4,7 @@ module Hotpages::Extensions::I18n
   extend Hotpages::Extension
 
   prepending "#{name}::Page", to: "Hotpages::Page"
-  prepending "#{name}::PageFinder", to: "Hotpages::Page::Finder"
+  prepending "#{name}::PageFinder", to: "Hotpages::PageFinder"
   prepending "#{name}::Site", to: "Hotpages::Site"
   prepending "#{name}::UrlHelper", to: "Hotpages::Helpers::UrlHelper"
   add_helper "#{name}::Helper"

--- a/lib/hotpages/extensions/page_mtime.rb
+++ b/lib/hotpages/extensions/page_mtime.rb
@@ -2,7 +2,7 @@ module Hotpages::Extensions::PageMtime
   extend Hotpages::Extension
 
   including "#{name}::Page", to: "Hotpages::Page"
-  including "#{name}::Template", to: "Hotpages::Page::Template"
+  including "#{name}::Template", to: "Hotpages::Template"
 
   module Page
     def last_modified_at

--- a/lib/hotpages/extensions/template_path_annotation.rb
+++ b/lib/hotpages/extensions/template_path_annotation.rb
@@ -1,7 +1,7 @@
 module Hotpages::Extensions::TemplatePathAnnotation
   extend Hotpages::Extension
 
-  prepending to: "Hotpages::Page::Template"
+  prepending to: "Hotpages::Template"
 
   def render_in(context, locals = {}, &block)
     content = super

--- a/lib/hotpages/helpers/markdown_helper.rb
+++ b/lib/hotpages/helpers/markdown_helper.rb
@@ -17,7 +17,7 @@ module Hotpages::Helpers::MarkdownHelper
       line
     end.join
 
-    template = Hotpages::Page::Template.new("md.erb") { unindented_content }
+    template = Hotpages::Template.new("md.erb") { unindented_content }
     template.render_in(rendering_context, locals)
   end
 end

--- a/lib/hotpages/helpers/page_finding.rb
+++ b/lib/hotpages/helpers/page_finding.rb
@@ -10,6 +10,6 @@ module Hotpages::Helpers::PageFinding
   private
 
   def page_finder
-    @page_finder ||= Hotpages::Page::Finder.new(site)
+    @page_finder ||= Hotpages::PageFinder.new(site)
   end
 end

--- a/lib/hotpages/page/renderable.rb
+++ b/lib/hotpages/page/renderable.rb
@@ -5,9 +5,9 @@ module Hotpages::Page::Renderable
   def page_template
     @page_template ||= begin
       if template_extension.nil? # `nil` if no template file is provided
-        Hotpages::Page::Template.new(body_type) { body }
+        Hotpages::Template.new(body_type) { body }
       else
-        Hotpages::Page::Template.new(@template_extension, base_path:, directory: site.pages_path)
+        Hotpages::Template.new(@template_extension, base_path:, directory: site.pages_path)
       end
     end
   end

--- a/lib/hotpages/page/rendering_context.rb
+++ b/lib/hotpages/page/rendering_context.rb
@@ -4,7 +4,7 @@ class Hotpages::Page::RenderingContext
 
   def initialize(page)
     @page = page
-    @template_finder = Hotpages::Page::Template::Finder.new(page.base_path, page.site)
+    @template_finder = Hotpages::TemplateFinder.new(page.base_path, page.site)
     @cached_page_content = nil
     @captured_contents = {}
     @buf = ""

--- a/lib/hotpages/page_finder.rb
+++ b/lib/hotpages/page_finder.rb
@@ -1,4 +1,4 @@
-class Hotpages::Page::Finder
+class Hotpages::PageFinder
   using Hotpages::Support::StringInflections
 
   IGNORED_PATH_REGEXP = Hotpages::Page::Instantiation::IGNORED_PATH_REGEXP

--- a/lib/hotpages/template.rb
+++ b/lib/hotpages/template.rb
@@ -4,7 +4,7 @@ require "erubi/capture_block"
 Tilt.register(Tilt::PlainTemplate, "txt")
 Tilt.register(Tilt::PlainTemplate, "xml")
 
-class Hotpages::Page::Template
+class Hotpages::Template
   ERB_OPTIONS = { engine_class: Erubi::CaptureBlockEngine, bufvar: "@buf" }.freeze
 
   def initialize(extension, base_path: nil, directory: nil, &body)

--- a/lib/hotpages/template_finder.rb
+++ b/lib/hotpages/template_finder.rb
@@ -1,4 +1,4 @@
-class Hotpages::Page::Template::Finder
+class Hotpages::TemplateFinder
   PathData = Data.define(:base_path, :extension) do
     def self.from_absolute_path(absolute_path)
       fragments = absolute_path.split(".")
@@ -16,7 +16,7 @@ class Hotpages::Page::Template::Finder
 
   def find!(template_path)
     data = path_data_for(template_path)
-    Hotpages::Page::Template.new(data.extension, base_path: data.base_path)
+    Hotpages::Template.new(data.extension, base_path: data.base_path)
   end
 
   private


### PR DESCRIPTION
- Updated `Hotpages::Page::Template` to `Hotpages::Template` for consistency.
- Renamed `lib/hotpages/page/template.rb` to `lib/hotpages/template.rb`.
- Renamed `lib/hotpages/page/template/finder.rb` to `lib/hotpages/template_finder.rb`.
- Adjusted references to the updated class and file paths across the codebaseT